### PR TITLE
Add datalayer renaming to gtm target

### DIFF
--- a/src/targets/google-tag-manager/__tests__/google-tag-manager.test.js
+++ b/src/targets/google-tag-manager/__tests__/google-tag-manager.test.js
@@ -1,8 +1,11 @@
 const { GoogleTagManager } = require('../google-tag-manager');
 
-beforeEach(() => { window.dataLayer = undefined; });
+beforeEach(() => {
+  window.dataLayer = undefined;
+  window.iAmADataLayer = undefined;
+});
 
-describe('GoogleTagManager(events)', () => {
+describe('GoogleTagManager({...settings})(events)', () => {
   describe('When given an array of events', () => {
     it('pushes those events to the data layer', () => {
       const events = [
@@ -11,10 +14,28 @@ describe('GoogleTagManager(events)', () => {
       ];
 
       window.dataLayer = { push: jest.fn() };
-      GoogleTagManager(events);
+      GoogleTagManager()(events);
 
       expect(window.dataLayer.push).toHaveBeenCalledWith(events[0]);
       expect(window.dataLayer.push).toHaveBeenCalledWith(events[1]);
+    });
+  });
+
+  describe('When settings has dataLayerName: iAmADataLayer', () => {
+    it('pushes events to iAmADataLayer data layer', () => {
+      const settings = {
+        dataLayerName: 'iAmADataLayer',
+      };
+      const events = [
+        { event: 'some-event' },
+        { event: 'some-other-event' },
+      ];
+
+      window[settings.dataLayerName] = { push: jest.fn() };
+      GoogleTagManager(settings)(events);
+
+      expect(window[settings.dataLayerName].push).toHaveBeenCalledWith(events[0]);
+      expect(window[settings.dataLayerName].push).toHaveBeenCalledWith(events[1]);
     });
   });
 
@@ -23,7 +44,7 @@ describe('GoogleTagManager(events)', () => {
       const events = [{ hitType: 'pageview' }];
 
       window.dataLayer = { push: jest.fn() };
-      GoogleTagManager(events);
+      GoogleTagManager()(events);
 
       const expected = {
         event: 'pageview',
@@ -33,10 +54,20 @@ describe('GoogleTagManager(events)', () => {
     });
   });
 
-  describe('When dataLayer is not defined', () => {
+  describe('When default dataLayer is not defined', () => {
     it('should throw an error informing the user.', () => {
       const events = [{ hitType: 'pageview' }];
-      expect(() => GoogleTagManager(events)).toThrow('window.dataLayer is not defined. Have you forgotten to include Google Tag Manager and dataLayer?');
+      expect(() => GoogleTagManager()(events)).toThrow('window.dataLayer is not defined. Have you forgotten to include Google Tag Manager and dataLayer?');
+    });
+  });
+
+  describe('When iAmADataLayer custom named dataLayer is not defined', () => {
+    it('should throw an error informing the user.', () => {
+      const settings = {
+        dataLayerName: 'iAmADataLayer',
+      };
+      const events = [{ hitType: 'pageview' }];
+      expect(() => GoogleTagManager(settings)(events)).toThrow('window.iAmADataLayer is not defined. Have you forgotten to include Google Tag Manager and dataLayer?');
     });
   });
 });

--- a/src/targets/google-tag-manager/google-tag-manager.js
+++ b/src/targets/google-tag-manager/google-tag-manager.js
@@ -1,9 +1,9 @@
-function GoogleTagManager(events) {
+const GoogleTagManager = ({ dataLayerName = 'dataLayer' } = {}) => (events) => {
   if (typeof window === 'undefined') {
     return;
   }
-  if (!window.dataLayer || typeof window.dataLayer.push !== 'function') {
-    throw new Error('window.dataLayer is not defined. Have you forgotten to include Google Tag Manager and dataLayer?');
+  if (!window[dataLayerName] || typeof window[dataLayerName].push !== 'function') {
+    throw new Error(`redux-beacon error: window.${dataLayerName} is not defined. Have you forgotten to include Google Tag Manager and dataLayer?`);
   }
   events.forEach((event) => {
     const eventToPush = (() => {
@@ -12,8 +12,8 @@ function GoogleTagManager(events) {
       }
       return event;
     })();
-    window.dataLayer.push(eventToPush);
+    window[dataLayerName].push(eventToPush);
   });
-}
+};
 
 module.exports = { GoogleTagManager };


### PR DESCRIPTION
* GoogleTagManager new signature is like
`GoogleTagManager({ ...settings })(eventArray)`
* implemented **dataLayerName** setting. Default value is `'dataLayer'`